### PR TITLE
Removed QtDocGallery submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -106,12 +106,6 @@
 	url = https://github.com/qt/qtfeedback.git
 	branch = master
 	status = ignore
-[submodule "qtdocgallery"]
-	depends = qtdeclarative
-	path = qtdocgallery
-	url = https://github.com/qt/qtdocgallery.git
-	branch = master
-	status = ignore
 [submodule "qtpim"]
 	depends = qtdeclarative
 	path = qtpim


### PR DESCRIPTION
Removed the QtDocGallery submodule since we don't ship it.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>